### PR TITLE
Fix scanned location range in UI when no-pokemon is True (#2069)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
     "Store": true,
     "centerLat": true,
     "centerLng": true,
+    "showConfig": true,	
     "pageLoaded": true,
     "countMarkers": true,
     "skel": true,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -948,7 +948,7 @@ function setupScannedMarker(item) {
         map: map,
         clickable: false,
         center: circleCenter,
-        radius: 70, // metres
+        radius: (showConfig.pokemons === true ? 70 : 450), // metres
         fillColor: getColorByDate(item['last_modified']),
         fillOpacity: 0.1,
         strokeWeight: 1,

--- a/templates/map.html
+++ b/templates/map.html
@@ -422,6 +422,7 @@
     <script>
       var centerLat = {{lat}};
       var centerLng = {{lng}};
+      var showConfig = {{show|tojson|safe}};	  
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>


### PR DESCRIPTION
* Fix scanned location range in UI when no-pokemon is True

* Fix spacing

* Fixed tab spacing to spaces.

* Fixed spacing.

Sorry for double commit, I'm using Github's editor.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
